### PR TITLE
feat: support for decimal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(monkey_lib
     source/ast/builtin_function_expression.cpp
     source/ast/call_expression.cpp
     source/ast/callable_expression.cpp
+    source/ast/decimal_literal.cpp
     source/ast/function_expression.cpp
     source/ast/hash_literal_expression.cpp
     source/ast/identifier.cpp

--- a/source/ast/decimal_literal.cpp
+++ b/source/ast/decimal_literal.cpp
@@ -2,7 +2,9 @@
 
 #include "decimal_literal.hpp"
 
+#include "util.hpp"
+
 auto decimal_literal::string() const -> std::string
 {
-    return std::to_string(value);
+    return decimal_to_string(value);
 }

--- a/source/ast/decimal_literal.cpp
+++ b/source/ast/decimal_literal.cpp
@@ -1,0 +1,8 @@
+#include <string>
+
+#include "decimal_literal.hpp"
+
+auto decimal_literal::string() const -> std::string
+{
+    return std::to_string(value);
+}

--- a/source/ast/decimal_literal.hpp
+++ b/source/ast/decimal_literal.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "expression.hpp"
+
+struct decimal_literal : expression
+{
+    [[nodiscard]] auto string() const -> std::string override;
+    [[nodiscard]] auto eval(environment* env) const -> object* override;
+    auto compile(compiler& comp) const -> void override;
+
+    double value {};
+};

--- a/source/ast/util.hpp
+++ b/source/ast/util.hpp
@@ -16,3 +16,8 @@ auto join(const std::vector<Expression*>& nodes, std::string_view sep = {}) -> s
         nodes.cbegin(), nodes.cend(), std::back_inserter(strs), [](const auto& node) { return node->string(); });
     return fmt::format("{}", fmt::join(strs.cbegin(), strs.cend(), sep));
 }
+
+inline auto decimal_to_string(double d) -> std::string
+{
+    return fmt::format("{}", d);
+}

--- a/source/compiler/ast_compile.cpp
+++ b/source/compiler/ast_compile.cpp
@@ -6,6 +6,7 @@
 #include <ast/boolean.hpp>
 #include <ast/builtin_function_expression.hpp>
 #include <ast/call_expression.hpp>
+#include <ast/decimal_literal.hpp>
 #include <ast/expression.hpp>
 #include <ast/function_expression.hpp>
 #include <ast/hash_literal_expression.hpp>
@@ -130,6 +131,11 @@ auto index_expression::compile(compiler& comp) const -> void
 auto integer_literal::compile(compiler& comp) const -> void
 {
     comp.emit(opcodes::constant, comp.add_constant(make<integer_object>(value)));
+}
+
+auto decimal_literal::compile(compiler& comp) const -> void
+{
+    comp.emit(opcodes::constant, comp.add_constant(make<decimal_object>(value)));
 }
 
 auto program::compile(compiler& comp) const -> void

--- a/source/eval/ast_eval.cpp
+++ b/source/eval/ast_eval.cpp
@@ -861,6 +861,10 @@ TEST_CASE("errorHandling")
 
     std::array tests {
         et {
+            "5 / 0;",
+            "division by zero",
+        },
+        et {
             "5 + true;",
             "type mismatch: integer + boolean",
         },

--- a/source/eval/object.cpp
+++ b/source/eval/object.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <ios>
 #include <iterator>
@@ -37,6 +38,13 @@ auto invert_bool_object(const object* b) -> const object*
 auto object_eq(const object& lhs, const object& rhs) -> bool
 {
     return (lhs == rhs) == &true_obj;
+}
+
+constexpr auto epsilon = 1e-9;
+
+auto are_almost_equal(double a, double b) -> bool
+{
+    return std::fabs(a - b) < epsilon;
 }
 }  // namespace
 
@@ -230,7 +238,11 @@ auto integer_object::operator*(const object& other) const -> const object*
 auto integer_object::operator/(const object& other) const -> const object*
 {
     if (other.is(integer)) {
-        return make<integer_object>(value / other.as<integer_object>()->value);
+        const auto other_value = other.as<integer_object>()->value;
+        if (other_value == 0) {
+            return make_error("division by zero");
+        }
+        return make<integer_object>(value / other_value);
     }
     if (other.is(decimal)) {
         return make<decimal_object>(static_cast<decimal_object::value_type>(value) / other.as<decimal_object>()->value);
@@ -265,7 +277,7 @@ auto integer_object::operator>(const object& other) const -> const object*
 auto decimal_object::operator==(const object& other) const -> const object*
 {
     if (other.is(type())) {
-        return native_bool_to_object(value == other.as<decimal_object>()->value);
+        return native_bool_to_object(are_almost_equal(value, other.as<decimal_object>()->value));
     }
     return nullptr;
 }

--- a/source/eval/object.cpp
+++ b/source/eval/object.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <ios>
+#include <iterator>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -13,6 +14,61 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <overloaded.hpp>
+
+#include "util.hpp"
+
+namespace
+{
+const boolean_object false_obj {/*val=*/false};
+const boolean_object true_obj {/*val=*/true};
+const null_object null_obj;
+
+auto invert_bool_object(const object* b) -> const object*
+{
+    if (b == &false_obj) {
+        return &true_obj;
+    }
+    if (b == &true_obj) {
+        return &false_obj;
+    }
+    return nullptr;
+}
+
+auto object_eq(const object& lhs, const object& rhs) -> bool
+{
+    return (lhs == rhs) == &true_obj;
+}
+}  // namespace
+
+auto native_bool_to_object(bool val) -> const object*
+{
+    if (val) {
+        return &true_obj;
+    }
+    return &false_obj;
+}
+
+auto native_true() -> const object*
+{
+    return &true_obj;
+}
+
+auto native_false() -> const object*
+{
+    return &false_obj;
+}
+
+auto native_null() -> const object*
+{
+    return &null_obj;
+}
+
+auto object::operator!=(const object& other) const -> const object*
+{
+    return invert_bool_object(*this == other);
+}
+
+using enum object::object_type;
 
 builtin_object::builtin_object(const builtin_function_expression* bltn)
 
@@ -59,9 +115,41 @@ auto string_object::hash_key() const -> hash_key_type
     return value;
 }
 
-auto string_object::equals_to(const object* other) const -> bool
+auto string_object::operator==(const object& other) const -> const object*
 {
-    return other->is(type()) && other->as<string_object>()->value == value;
+    return native_bool_to_object(other.is(type()) && other.as<string_object>()->value == value);
+}
+
+auto string_object::operator<(const object& other) const -> const object*
+{
+    if (other.is(type())) {
+        return native_bool_to_object(value < other.as<string_object>()->value);
+    }
+    return nullptr;
+}
+
+auto string_object::operator>(const object& other) const -> const object*
+{
+    if (other.is(type())) {
+        return native_bool_to_object(value > other.as<string_object>()->value);
+    }
+    return nullptr;
+}
+
+auto string_object::operator+(const object& other) const -> const object*
+{
+    if (other.is(string)) {
+        return make<string_object>(value + other.as<string_object>()->value);
+    }
+    return nullptr;
+}
+
+auto string_object::operator*(const object& other) const -> const object*
+{
+    if (other.is(integer)) {
+        return evaluate_sequence_mul(this, &other);
+    }
+    return nullptr;
 }
 
 auto boolean_object::hash_key() const -> hash_key_type
@@ -69,9 +157,185 @@ auto boolean_object::hash_key() const -> hash_key_type
     return value;
 }
 
+auto boolean_object::operator==(const object& other) const -> const object*
+{
+    return native_bool_to_object(other.is(type()) && other.as<boolean_object>()->value == value);
+}
+
+auto boolean_object::operator<(const object& other) const -> const object*
+{
+    if (other.is(boolean)) {
+        return native_bool_to_object(static_cast<int>(value) < static_cast<int>(other.as<boolean_object>()->value));
+    }
+    return nullptr;
+}
+
+auto boolean_object::operator>(const object& other) const -> const object*
+{
+    if (other.is(boolean)) {
+        return native_bool_to_object(static_cast<int>(value) > static_cast<int>(other.as<boolean_object>()->value));
+    }
+    return nullptr;
+}
+
 auto integer_object::hash_key() const -> hash_key_type
 {
     return value;
+}
+
+auto integer_object::operator==(const object& other) const -> const object*
+{
+    if (other.is(type())) {
+        return native_bool_to_object(other.as<integer_object>()->value == value);
+    }
+    return nullptr;
+}
+
+auto integer_object::operator+(const object& other) const -> const object*
+{
+    if (other.is(integer)) {
+        return make<integer_object>(value + other.as<integer_object>()->value);
+    }
+    if (other.is(decimal)) {
+        return make<decimal_object>(static_cast<decimal_object::value_type>(value) + other.as<decimal_object>()->value);
+    }
+    return nullptr;
+}
+
+auto integer_object::operator-(const object& other) const -> const object*
+{
+    if (other.is(integer)) {
+        return make<integer_object>(value - other.as<integer_object>()->value);
+    }
+    if (other.is(decimal)) {
+        return make<decimal_object>(static_cast<decimal_object::value_type>(value) - other.as<decimal_object>()->value);
+    }
+    return nullptr;
+}
+
+auto integer_object::operator*(const object& other) const -> const object*
+{
+    if (other.is(integer)) {
+        return make<integer_object>(value * other.as<integer_object>()->value);
+    }
+    if (other.is(decimal)) {
+        return make<decimal_object>(static_cast<decimal_object::value_type>(value) * other.as<decimal_object>()->value);
+    }
+    if (other.is(array) || other.is(string)) {
+        return evaluate_sequence_mul(this, &other);
+    }
+    return nullptr;
+}
+
+auto integer_object::operator/(const object& other) const -> const object*
+{
+    if (other.is(integer)) {
+        return make<integer_object>(value / other.as<integer_object>()->value);
+    }
+    if (other.is(decimal)) {
+        return make<decimal_object>(static_cast<decimal_object::value_type>(value) / other.as<decimal_object>()->value);
+    }
+    return nullptr;
+}
+
+auto integer_object::operator<(const object& other) const -> const object*
+{
+    if (other.is(integer)) {
+        return native_bool_to_object(value < other.as<integer_object>()->value);
+    }
+    if (other.is(decimal)) {
+        return native_bool_to_object(static_cast<decimal_object::value_type>(value)
+                                     < other.as<decimal_object>()->value);
+    }
+    return nullptr;
+}
+
+auto integer_object::operator>(const object& other) const -> const object*
+{
+    if (other.is(integer)) {
+        return native_bool_to_object(value > other.as<integer_object>()->value);
+    }
+    if (other.is(decimal)) {
+        return native_bool_to_object(static_cast<decimal_object::value_type>(value)
+                                     > other.as<decimal_object>()->value);
+    }
+    return nullptr;
+}
+
+auto decimal_object::operator==(const object& other) const -> const object*
+{
+    if (other.is(type())) {
+        return native_bool_to_object(value == other.as<decimal_object>()->value);
+    }
+    return nullptr;
+}
+
+auto decimal_object::operator+(const object& other) const -> const object*
+{
+    if (other.is(decimal)) {
+        return make<decimal_object>(value + other.as<decimal_object>()->value);
+    }
+    if (other.is(integer)) {
+        return make<decimal_object>(value + static_cast<decimal_object::value_type>(other.as<integer_object>()->value));
+    }
+    return nullptr;
+}
+
+auto decimal_object::operator-(const object& other) const -> const object*
+{
+    if (other.is(decimal)) {
+        return make<decimal_object>(value - other.as<decimal_object>()->value);
+    }
+    if (other.is(integer)) {
+        return make<decimal_object>(value - static_cast<decimal_object::value_type>(other.as<integer_object>()->value));
+    }
+    return nullptr;
+}
+
+auto decimal_object::operator*(const object& other) const -> const object*
+{
+    if (other.is(decimal)) {
+        return make<decimal_object>(value * other.as<decimal_object>()->value);
+    }
+    if (other.is(integer)) {
+        return make<decimal_object>(value * static_cast<decimal_object::value_type>(other.as<integer_object>()->value));
+    }
+    return nullptr;
+}
+
+auto decimal_object::operator/(const object& other) const -> const object*
+{
+    if (other.is(decimal)) {
+        return make<decimal_object>(value / other.as<decimal_object>()->value);
+    }
+    if (other.is(integer)) {
+        return make<decimal_object>(value / static_cast<decimal_object::value_type>(other.as<integer_object>()->value));
+    }
+    return nullptr;
+}
+
+auto decimal_object::operator<(const object& other) const -> const object*
+{
+    if (other.is(decimal)) {
+        return native_bool_to_object(value < other.as<decimal_object>()->value);
+    }
+    if (other.is(integer)) {
+        return native_bool_to_object(value
+                                     < static_cast<decimal_object::value_type>(other.as<integer_object>()->value));
+    }
+    return nullptr;
+}
+
+auto decimal_object::operator>(const object& other) const -> const object*
+{
+    if (other.is(decimal)) {
+        return native_bool_to_object(value > other.as<decimal_object>()->value);
+    }
+    if (other.is(integer)) {
+        return native_bool_to_object(value
+                                     > static_cast<decimal_object::value_type>(other.as<integer_object>()->value));
+    }
+    return nullptr;
 }
 
 auto builtin_object::inspect() const -> std::string
@@ -82,6 +346,14 @@ auto builtin_object::inspect() const -> std::string
 auto function_object::inspect() const -> std::string
 {
     return callable->string();
+}
+
+auto error_object::operator==(const object& other) const -> const object*
+{
+    if (other.is(type())) {
+        return native_bool_to_object(message == other.as<error_object>()->message);
+    }
+    return nullptr;
 }
 
 auto array_object::inspect() const -> std::string
@@ -99,17 +371,40 @@ auto array_object::inspect() const -> std::string
     return strm.str();
 }
 
-auto array_object::equals_to(const object* other) const -> bool
+auto array_object::operator==(const object& other) const -> const object*
 {
-    if (!other->is(type()) || other->as<array_object>()->value.size() != value.size()) {
-        return false;
+    if (other.is(type())) {
+        if (value.size() != other.as<array_object>()->value.size()) {
+            return native_false();
+        }
+        const auto& other_value = other.as<array_object>()->value;
+        const auto eq = std::equal(value.cbegin(),
+                                   value.cend(),
+                                   other_value.cbegin(),
+                                   other_value.cend(),
+                                   [](const object* a, const object* b) { return object_eq(*a, *b); });
+        return native_bool_to_object(eq);
     }
-    const auto& other_elements = other->as<array_object>()->value;
-    return std::equal(value.cbegin(),
-                      value.cend(),
-                      other_elements.cbegin(),
-                      other_elements.cend(),
-                      [](const object* a, const object* b) { return a->equals_to(b); });
+    return nullptr;
+}
+
+auto array_object::operator*(const object& other) const -> const object*
+{
+    if (other.is(integer)) {
+        return evaluate_sequence_mul(this, &other);
+    }
+    return nullptr;
+}
+
+auto array_object::operator+(const object& other) const -> const object*
+{
+    if (other.is(array)) {
+        value_type concat = value;
+        const auto& other_value = other.as<array_object>()->value;
+        std::copy(other_value.cbegin(), other_value.cend(), std::back_inserter(concat));
+        return make<array_object>(std::move(concat));
+    }
+    return nullptr;
 }
 
 auto operator<<(std::ostream& strm, const hashable_object::hash_key_type& t) -> std::ostream&
@@ -140,48 +435,27 @@ auto hash_object::inspect() const -> std::string
     return strm.str();
 }
 
-auto hash_object::equals_to(const object* other) const -> bool
+auto hash_object::operator==(const object& other) const -> const object*
 {
-    if (!other->is(type()) || other->as<hash_object>()->value.size() != value.size()) {
-        return false;
+    if (!other.is(type()) || other.as<hash_object>()->value.size() != value.size()) {
+        return native_false();
     }
-    const auto& other_pairs = other->as<hash_object>()->value;
-    return std::all_of(value.cbegin(),
-                       value.cend(),
-                       [other_pairs](const auto& pair)
-                       {
-                           const auto& [key, value] = pair;
-                           auto it = other_pairs.find(key);
-                           return it != other_pairs.cend() && it->second->equals_to(value);
-                       });
+    const auto& other_value = other.as<hash_object>()->value;
+    const auto eq = std::all_of(value.cbegin(),
+                                value.cend(),
+                                [&other_value](const auto& pair)
+                                {
+                                    const auto& [key, value] = pair;
+                                    auto it = other_value.find(key);
+                                    return it != other_value.cend() && object_eq(*(it->second), *value);
+                                });
+    return native_bool_to_object(eq);
 }
 
-namespace
+auto null_object::operator==(const object& other) const -> const object*
 {
-const boolean_object false_obj {/*val=*/false};
-const boolean_object true_obj {/*val=*/true};
-const null_object null_obj;
-}  // namespace
-
-auto native_bool_to_object(bool val) -> const object*
-{
-    if (val) {
-        return &true_obj;
+    if (other.is(type())) {
+        return native_true();
     }
-    return &false_obj;
-}
-
-auto native_true() -> const object*
-{
-    return &true_obj;
-}
-
-auto native_false() -> const object*
-{
-    return &false_obj;
-}
-
-auto native_null() -> const object*
-{
-    return &null_obj;
+    return nullptr;
 }

--- a/source/eval/object.cpp
+++ b/source/eval/object.cpp
@@ -374,10 +374,10 @@ auto array_object::inspect() const -> std::string
 auto array_object::operator==(const object& other) const -> const object*
 {
     if (other.is(type())) {
-        if (value.size() != other.as<array_object>()->value.size()) {
+        const auto& other_value = other.as<array_object>()->value;
+        if (other_value.size() != value.size()) {
             return native_false();
         }
-        const auto& other_value = other.as<array_object>()->value;
         const auto eq = std::equal(value.cbegin(),
                                    value.cend(),
                                    other_value.cbegin(),

--- a/source/eval/object.cpp
+++ b/source/eval/object.cpp
@@ -27,6 +27,8 @@ auto operator<<(std::ostream& ostrm, object::object_type type) -> std::ostream&
     switch (type) {
         case integer:
             return ostrm << "integer";
+        case decimal:
+            return ostrm << "decimal";
         case boolean:
             return ostrm << "boolean";
         case string:

--- a/source/eval/object.hpp
+++ b/source/eval/object.hpp
@@ -83,7 +83,7 @@ struct integer_object : hashable_object
 {
     using value_type = std::int64_t;
 
-    explicit integer_object(int64_t val)
+    explicit integer_object(value_type val)
         : value {val}
     {
     }
@@ -108,7 +108,7 @@ struct decimal_object : object
 {
     using value_type = double;
 
-    explicit decimal_object(double val)
+    explicit decimal_object(value_type val)
         : value {val}
     {
     }
@@ -131,7 +131,7 @@ struct boolean_object : hashable_object
 {
     using value_type = bool;
 
-    explicit boolean_object(bool val)
+    explicit boolean_object(value_type val)
         : value {val}
     {
     }
@@ -162,7 +162,7 @@ struct string_object : hashable_object
 
     string_object() = default;
 
-    explicit string_object(std::string val)
+    explicit string_object(value_type val)
         : value {std::move(val)}
     {
     }

--- a/source/eval/object.hpp
+++ b/source/eval/object.hpp
@@ -18,6 +18,7 @@ struct object
     enum class object_type : std::uint8_t
     {
         integer,
+        decimal,
         boolean,
         string,
         null,
@@ -98,6 +99,29 @@ struct integer_object : hashable_object
     [[nodiscard]] auto equals_to(const object* other) const -> bool override
     {
         return other->is(type()) && other->as<integer_object>()->value == value;
+    }
+
+    value_type value {};
+};
+
+struct decimal_object : object
+{
+    using value_type = double;
+
+    explicit decimal_object(double val)
+        : value {val}
+    {
+    }
+
+    [[nodiscard]] auto is_truthy() const -> bool override { return value != 0.0; }
+
+    [[nodiscard]] auto type() const -> object_type override { return object_type::decimal; }
+
+    [[nodiscard]] auto inspect() const -> std::string override { return std::to_string(value); }
+
+    [[nodiscard]] auto equals_to(const object* other) const -> bool override
+    {
+        return other->is(type()) && other->as<decimal_object>()->value == value;
     }
 
     value_type value {};

--- a/source/eval/object.hpp
+++ b/source/eval/object.hpp
@@ -59,9 +59,9 @@ struct object
     [[nodiscard]] virtual auto type() const -> object_type = 0;
     [[nodiscard]] virtual auto inspect() const -> std::string = 0;
 
-    [[nodiscard]] virtual auto operator==(const object& /*other*/) const -> const object* { return nullptr; }
+    [[nodiscard]] auto operator!=(const object& other) const -> const object*;
 
-    [[nodiscard]] virtual auto operator!=(const object& other) const -> const object*;
+    [[nodiscard]] virtual auto operator==(const object& /*other*/) const -> const object* { return nullptr; }
 
     [[nodiscard]] virtual auto operator<(const object& /*other*/) const -> const object* { return nullptr; }
 

--- a/source/eval/object.hpp
+++ b/source/eval/object.hpp
@@ -103,6 +103,8 @@ struct integer_object : hashable_object
 {
     using value_type = std::int64_t;
 
+    integer_object() = default;
+
     explicit integer_object(value_type val)
         : value {val}
     {
@@ -131,6 +133,8 @@ struct decimal_object : object
 {
     using value_type = double;
 
+    decimal_object() = default;
+
     explicit decimal_object(value_type val)
         : value {val}
     {
@@ -156,6 +160,8 @@ struct decimal_object : object
 struct boolean_object : hashable_object
 {
     using value_type = bool;
+
+    boolean_object() = default;
 
     explicit boolean_object(value_type val)
         : value {val}
@@ -274,6 +280,8 @@ struct array_object : object
 struct hash_object : object
 {
     using value_type = std::unordered_map<hashable_object::hash_key_type, const object*>;
+
+    hash_object() = default;
 
     explicit hash_object(value_type&& hsh)
         : value {std::move(hsh)}

--- a/source/eval/object.hpp
+++ b/source/eval/object.hpp
@@ -183,6 +183,8 @@ struct string_object : hashable_object
 {
     using value_type = std::string;
 
+    string_object() = default;
+
     explicit string_object(value_type val)
         : value {std::move(val)}
     {
@@ -243,6 +245,8 @@ auto make_error(fmt::format_string<T...> fmt, T&&... args) -> object*
 struct array_object : object
 {
     using value_type = std::vector<const object*>;
+
+    array_object() = default;
 
     explicit array_object(value_type&& arr)
         : value {std::move(arr)}

--- a/source/eval/object.hpp
+++ b/source/eval/object.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
@@ -43,6 +44,7 @@ struct object
     template<typename T>
     [[nodiscard]] auto as() const -> const T*
     {
+        assert(type() == T {}.type());
         return static_cast<const T*>(this);
     }
 
@@ -68,6 +70,8 @@ template<>
 struct fmt::formatter<object::object_type> : ostream_formatter
 {
 };
+
+auto cast_to_double(const object* obj) -> std::optional<double>;
 
 struct hashable_object : object
 {
@@ -196,6 +200,8 @@ auto native_null() -> const object*;
 
 struct error_object : object
 {
+    error_object() = default;
+
     explicit error_object(std::string msg)
         : message {std::move(msg)}
     {

--- a/source/eval/object.hpp
+++ b/source/eval/object.hpp
@@ -7,6 +7,7 @@
 #include <variant>
 #include <vector>
 
+#include <ast/util.hpp>
 #include <code/code.hpp>
 #include <compiler/symbol_table.hpp>
 #include <eval/environment.hpp>
@@ -117,7 +118,7 @@ struct decimal_object : object
 
     [[nodiscard]] auto type() const -> object_type override { return object_type::decimal; }
 
-    [[nodiscard]] auto inspect() const -> std::string override { return std::to_string(value); }
+    [[nodiscard]] auto inspect() const -> std::string override { return decimal_to_string(value); }
 
     [[nodiscard]] auto equals_to(const object* other) const -> bool override
     {

--- a/source/eval/object.hpp
+++ b/source/eval/object.hpp
@@ -44,7 +44,6 @@ struct object
     template<typename T>
     [[nodiscard]] auto as() const -> const T*
     {
-        assert(type() == T {}.type());
         return static_cast<const T*>(this);
     }
 
@@ -103,8 +102,6 @@ struct integer_object : hashable_object
 {
     using value_type = std::int64_t;
 
-    integer_object() = default;
-
     explicit integer_object(value_type val)
         : value {val}
     {
@@ -133,8 +130,6 @@ struct decimal_object : object
 {
     using value_type = double;
 
-    decimal_object() = default;
-
     explicit decimal_object(value_type val)
         : value {val}
     {
@@ -160,8 +155,6 @@ struct decimal_object : object
 struct boolean_object : hashable_object
 {
     using value_type = bool;
-
-    boolean_object() = default;
 
     explicit boolean_object(value_type val)
         : value {val}
@@ -189,8 +182,6 @@ auto native_false() -> const object*;
 struct string_object : hashable_object
 {
     using value_type = std::string;
-
-    string_object() = default;
 
     explicit string_object(value_type val)
         : value {std::move(val)}
@@ -229,8 +220,6 @@ auto native_null() -> const object*;
 
 struct error_object : object
 {
-    error_object() = default;
-
     explicit error_object(std::string msg)
         : message {std::move(msg)}
     {
@@ -255,8 +244,6 @@ struct array_object : object
 {
     using value_type = std::vector<const object*>;
 
-    array_object() = default;
-
     explicit array_object(value_type&& arr)
         : value {std::move(arr)}
     {
@@ -280,8 +267,6 @@ struct array_object : object
 struct hash_object : object
 {
     using value_type = std::unordered_map<hashable_object::hash_key_type, const object*>;
-
-    hash_object() = default;
 
     explicit hash_object(value_type&& hsh)
         : value {std::move(hsh)}

--- a/source/eval/object.hpp
+++ b/source/eval/object.hpp
@@ -59,8 +59,23 @@ struct object
     [[nodiscard]] virtual auto type() const -> object_type = 0;
     [[nodiscard]] virtual auto inspect() const -> std::string = 0;
 
-    [[nodiscard]] virtual auto equals_to(const object* /*other*/) const -> bool { return false; }
+    [[nodiscard]] virtual auto operator==(const object& /*other*/) const -> const object* { return nullptr; }
 
+    [[nodiscard]] virtual auto operator!=(const object& other) const -> const object*;
+
+    [[nodiscard]] virtual auto operator<(const object& /*other*/) const -> const object* { return nullptr; }
+
+    [[nodiscard]] virtual auto operator>(const object& /*other*/) const -> const object* { return nullptr; }
+
+    [[nodiscard]] virtual auto operator*(const object& /*other*/) const -> const object* { return nullptr; }
+
+    [[nodiscard]] virtual auto operator+(const object& /*other*/) const -> const object* { return nullptr; }
+
+    [[nodiscard]] virtual auto operator-(const object& /*other*/) const -> const object* { return nullptr; }
+
+    [[nodiscard]] virtual auto operator/(const object& /*other*/) const -> const object* { return nullptr; }
+
+    // todo: return_object
     mutable bool is_return_value {};
 };
 
@@ -71,7 +86,7 @@ struct fmt::formatter<object::object_type> : ostream_formatter
 {
 };
 
-auto cast_to_double(const object* obj) -> std::optional<double>;
+auto native_bool_to_object(bool val) -> const object*;
 
 struct hashable_object : object
 {
@@ -101,10 +116,13 @@ struct integer_object : hashable_object
 
     [[nodiscard]] auto hash_key() const -> hash_key_type override;
 
-    [[nodiscard]] auto equals_to(const object* other) const -> bool override
-    {
-        return other->is(type()) && other->as<integer_object>()->value == value;
-    }
+    [[nodiscard]] auto operator==(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator<(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator>(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator+(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator-(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator*(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator/(const object& other) const -> const object* override;
 
     value_type value {};
 };
@@ -124,10 +142,13 @@ struct decimal_object : object
 
     [[nodiscard]] auto inspect() const -> std::string override { return decimal_to_string(value); }
 
-    [[nodiscard]] auto equals_to(const object* other) const -> bool override
-    {
-        return other->is(type()) && other->as<decimal_object>()->value == value;
-    }
+    [[nodiscard]] auto operator==(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator<(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator>(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator+(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator-(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator*(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator/(const object& other) const -> const object* override;
 
     value_type value {};
 };
@@ -149,17 +170,15 @@ struct boolean_object : hashable_object
 
     [[nodiscard]] auto hash_key() const -> hash_key_type override;
 
-    [[nodiscard]] auto equals_to(const object* other) const -> bool override
-    {
-        return other->is(type()) && other->as<boolean_object>()->value == value;
-    }
+    [[nodiscard]] auto operator==(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator<(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator>(const object& other) const -> const object* override;
 
     value_type value {};
 };
 
 auto native_true() -> const object*;
 auto native_false() -> const object*;
-auto native_bool_to_object(bool val) -> const object*;
 
 struct string_object : hashable_object
 {
@@ -182,7 +201,11 @@ struct string_object : hashable_object
 
     [[nodiscard]] auto hash_key() const -> hash_key_type override;
 
-    [[nodiscard]] auto equals_to(const object* other) const -> bool override;
+    [[nodiscard]] auto operator==(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator<(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator>(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator+(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator*(const object& other) const -> const object* override;
 
     value_type value;
 };
@@ -193,7 +216,7 @@ struct null_object : object
 
     [[nodiscard]] auto inspect() const -> std::string override { return "null"; }
 
-    [[nodiscard]] auto equals_to(const object* other) const -> bool override { return other->is(type()); }
+    [[nodiscard]] auto operator==(const object& other) const -> const object* override;
 };
 
 auto native_null() -> const object*;
@@ -211,10 +234,7 @@ struct error_object : object
 
     [[nodiscard]] auto inspect() const -> std::string override { return "ERROR: " + message; }
 
-    [[nodiscard]] auto equals_to(const object* other) const -> bool override
-    {
-        return other->is(type()) && other->as<error_object>()->message == message;
-    }
+    [[nodiscard]] auto operator==(const object& other) const -> const object* override;
 
     std::string message;
 };
@@ -244,7 +264,9 @@ struct array_object : object
 
     [[nodiscard]] auto inspect() const -> std::string override;
 
-    [[nodiscard]] auto equals_to(const object* other) const -> bool override;
+    [[nodiscard]] auto operator==(const object& other) const -> const object* override;
+    [[nodiscard]] auto operator*(const object& /*other*/) const -> const object* override;
+    [[nodiscard]] auto operator+(const object& other) const -> const object* override;
 
     value_type value;
 };
@@ -264,7 +286,7 @@ struct hash_object : object
 
     [[nodiscard]] auto inspect() const -> std::string override;
 
-    [[nodiscard]] auto equals_to(const object* other) const -> bool override;
+    [[nodiscard]] auto operator==(const object& other) const -> const object* override;
 
     value_type value;
 };

--- a/source/lexer/lexer.hpp
+++ b/source/lexer/lexer.hpp
@@ -15,7 +15,7 @@ class lexer final
     auto skip_whitespace() -> void;
     auto peek_char() -> std::string_view::value_type;
     auto read_identifier_or_keyword() -> token;
-    auto read_integer() -> token;
+    auto read_number() -> token;
     auto read_string() -> token;
     std::string_view m_input;
 

--- a/source/lexer/token_type.cpp
+++ b/source/lexer/token_type.cpp
@@ -34,6 +34,8 @@ auto operator<<(std::ostream& ostream, token_type type) -> std::ostream&
             return ostream << "identifier";
         case token_type::integer:
             return ostream << "integer";
+        case token_type::decimal:
+            return ostream << "decimal";
         case token_type::string:
             return ostream << "string";
         case token_type::let:

--- a/source/lexer/token_type.hpp
+++ b/source/lexer/token_type.hpp
@@ -44,6 +44,7 @@ enum class token_type : std::uint8_t
     // multi character tokens
     ident,
     integer,
+    decimal,
     string,
 
     // keywords

--- a/source/parser/parser.cpp
+++ b/source/parser/parser.cpp
@@ -23,6 +23,7 @@
 #include <ast/statements.hpp>
 #include <ast/string_literal.hpp>
 #include <ast/unary_expression.hpp>
+#include <ast/util.hpp>
 #include <doctest/doctest.h>
 #include <fmt/ranges.h>
 #include <gc.hpp>
@@ -556,7 +557,7 @@ auto require_decimal_literal(const expression* expr, double value) -> void
     REQUIRE(decimal_lit);
 
     REQUIRE_EQ(decimal_lit->value, value);
-    REQUIRE_EQ(decimal_lit->string(), std::to_string(value));
+    REQUIRE_EQ(decimal_lit->string(), decimal_to_string(value));
 }
 
 auto require_literal_expression(const expression* expr, const expected_value_type& expected) -> void

--- a/source/parser/parser.hpp
+++ b/source/parser/parser.hpp
@@ -31,6 +31,7 @@ class parser final
     auto parse_expression(int precedence) -> expression*;
     auto parse_identifier() const -> identifier*;
     auto parse_integer_literal() -> expression*;
+    auto parse_decimal_literal() -> expression*;
     auto parse_unary_expression() -> expression*;
     auto parse_binary_expression(expression* left) -> expression*;
     auto parse_boolean() -> expression*;

--- a/source/vm/vm.cpp
+++ b/source/vm/vm.cpp
@@ -226,6 +226,27 @@ auto vm::exec_binary_op(opcodes opcode) -> void
         }
         return;
     }
+    if (left->is(decimal) && right->is(decimal)) {
+        auto left_value = left->as<decimal_object>()->value;
+        auto right_value = right->as<decimal_object>()->value;
+        switch (opcode) {
+            case opcodes::sub:
+                push(make<decimal_object>(left_value - right_value));
+                break;
+            case opcodes::mul:
+                push(make<decimal_object>(left_value * right_value));
+                break;
+            case opcodes::div:
+                push(make<decimal_object>(left_value / right_value));
+                break;
+            case opcodes::add:
+                push(make<decimal_object>(left_value + right_value));
+                break;
+            default:
+                throw std::runtime_error(fmt::format("unknown decimal operator"));
+        }
+        return;
+    }
     if (left->is(string) && right->is(string)) {
         const auto& left_value = left->as<string_object>()->value;
         const auto& right_value = right->as<string_object>()->value;


### PR DESCRIPTION
This PR overhauls binary operators `==`, `!=`, `+`, `-`, `*`, `/`, `<` and `>` 

We also added handing of division by zero as an error.
We also added support for `array + array` while at it.

