### PR TITLE
chore: fix some clang tidy warnings

### DIFF
--- a/source/compiler/symbol_table.cpp
+++ b/source/compiler/symbol_table.cpp
@@ -10,7 +10,9 @@
 #include "symbol_table.hpp"
 
 #include <doctest/doctest.h>
+#include <fmt/base.h>
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 auto operator==(const symbol& lhs, const symbol& rhs) -> bool
 {
@@ -39,7 +41,7 @@ auto operator<<(std::ostream& ost, symbol_scope scope) -> std::ostream&
 
 auto operator<<(std::ostream& ost, const symbol& sym) -> std::ostream&
 {
-    return ost << fmt::format("symbol{{{}, {}, {}, {}}}", sym.name, sym.scope, sym.index, sym.ptr.has_value());
+    return ost << fmt::format("symbol{{{}, {}, {}, {}}}", sym.name, sym.scope, sym.index, sym.ptr);
 }
 
 auto operator<<(std::ostream& ost, const symbol_pointer& ptr) -> std::ostream&
@@ -135,7 +137,7 @@ auto symbol_table::resolve(const std::string& name, int level) -> std::optional<
     return std::nullopt;
 }
 
-auto symbol_table::free() const -> std::vector<symbol>
+auto symbol_table::free() const -> const std::vector<symbol>&
 {
     return m_free;
 }

--- a/source/compiler/symbol_table.hpp
+++ b/source/compiler/symbol_table.hpp
@@ -81,18 +81,12 @@ struct symbol_table
 
     [[nodiscard]] auto outer() const -> symbol_table* { return m_outer; }
 
-    [[nodiscard]] auto free() const -> std::vector<symbol>;
+    [[nodiscard]] auto inside_loop() const -> bool { return m_inside_loop; }
 
-    [[nodiscard]] auto inside_loop() const -> bool
-    {
-        return m_inside_loop;
-    }
+    [[nodiscard]] auto num_definitions() const -> size_t { return m_defs; }
 
-    ;
-
+    [[nodiscard]] auto free() const -> const std::vector<symbol>&;
     auto debug() const -> void;
-
-    [[nodiscard]] auto num_definitions() const -> size_t { return m_defs; };
 
   private:
     auto define_free(const symbol& sym) -> symbol;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <ast/builtin_function_expression.hpp>
+#include <code/code.hpp>
 #include <compiler/compiler.hpp>
 #include <compiler/symbol_table.hpp>
 #include <eval/environment.hpp>

--- a/source/vm/vm.cpp
+++ b/source/vm/vm.cpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -17,6 +18,7 @@
 #include <ast/program.hpp>
 #include <code/code.hpp>
 #include <compiler/compiler.hpp>
+#include <compiler/symbol_table.hpp>
 #include <doctest/doctest.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>

--- a/source/vm/vm.hpp
+++ b/source/vm/vm.hpp
@@ -13,7 +13,7 @@ constexpr size_t stack_size = 2048UL;
 constexpr size_t globals_size = 65536UL;
 constexpr size_t max_frames = 1024UL;
 
-using ssize_type = std::make_signed_t<size_t>;
+using ssize_type = int;
 
 struct frame
 {


### PR DESCRIPTION
- IWYU
- Extraneous ;
- Also use <fmt/std.h> for std::optional support